### PR TITLE
Add date convert

### DIFF
--- a/example.lua
+++ b/example.lua
@@ -49,7 +49,7 @@ AddEventHandler("onDatabaseConnect", function (databaseName)
         if #result > 0 then
             print("[MongoDB][Example] User is already created")
             printUser(result[1]._id)
-            exports.mongodb:updateOne({ collection="users", query = { _id = result[1]._id }, update = { ["$set"] = { first_name = "Bob" } } })
+            exports.mongodb:updateOne({ collection="users", query = { _id = result[1]._id }, update = { ["$set"] = { first_name = "Bob" , last_update = "day(" .. os.time() ..")"} } })
             return
         end
         print("[MongoDB][Example] User does not exist. Creating...")

--- a/example.lua
+++ b/example.lua
@@ -53,7 +53,7 @@ AddEventHandler("onDatabaseConnect", function (databaseName)
             return
         end
         print("[MongoDB][Example] User does not exist. Creating...")
-        exports.mongodb:insertOne({ collection="users", document = { username = username, password = "123" } }, function (success, result, insertedIds)
+        exports.mongodb:insertOne({ collection="users", document = { username = username, password = "123", ["date_nested.register_date"] = "day(" .. os.time() ..")" } }, function (success, result, insertedIds)
             if not success then
                 print("[MongoDB][Example] Error in insertOne: "..tostring(result))
                 return
@@ -72,7 +72,7 @@ AddEventHandler("onDatabaseConnect", function (databaseName)
         if result < 10 then
             local insertUsers = {}
             for i = 1, 10 do
-                table.insert(insertUsers, { username = "User"..i, password = "123456" })
+                table.insert(insertUsers, { username = "User"..i, password = "123456" , created_date = "day(" .. os.time() ..")"})
             end
 
             exports.mongodb:insert({ collection="users", documents = insertUsers }, function (success, result)

--- a/index.js
+++ b/index.js
@@ -122,7 +122,20 @@ function dbUpdate(params, callback, isUpdateOne) {
     query = utils.safeObjectArgument(params.query);
     update = utils.safeObjectArgument(params.update);
     options = utils.safeObjectArgument(params.options);
-
+    if(update.$set){ // Check if update has date() value
+        for(let k in update.$set){
+            updateValue = update.$set[k];
+            if(typeof(updateValue) == "string" && updateValue.indexOf("date(") > -1){ // date format
+                let unixTime = updateValue.substring(updateValue.indexOf("(")+1, updateValue.indexOf(")"))
+                try {
+                    unixTime = parseInt(unixTime) * 1000;
+                    update.$set[k] = new Date(unixTime)
+                } catch(err){
+                    console.log(`[MongoDB][WARNING] exports.update: Error "date value is not number".`)
+                }
+            }
+        }
+    }
     const cb = (err, res) => {
         if (err) {
             console.log(`[MongoDB][ERROR] exports.update: Error "${err.message}".`);

--- a/index.js
+++ b/index.js
@@ -55,6 +55,22 @@ function dbInsert(params, callback) {
     if (!documents || !Array.isArray(documents))
         return console.log(`[MongoDB][ERROR] exports.insert: Invalid 'params.documents' value. Expected object or array of objects.`);
 
+    for(let i=0,l=documents.length; i<l;i++){
+        for(let k in documents[i]){
+            insertDocument = documents[i][k];
+            console.log(insertDocument)
+            if(typeof(insertDocument) == "string" && insertDocument.indexOf("date(") > -1){ // date format
+                let unixTime = insertDocument.substring(insertDocument.indexOf("(")+1, insertDocument.indexOf(")"))
+                try {
+                    unixTime = parseInt(unixTime) * 1000;
+                    documents[i][k] = new Date(unixTime)
+                } catch(err){
+                    console.log(`[MongoDB][WARNING] exports.insert: Error "date value is not number".`)
+                }
+            }
+        }
+    }
+
     const options = utils.safeObjectArgument(params.options);
 
     collection.insertMany(documents, options, (err, result) => {


### PR DESCRIPTION
I just add date convert, So lua script can update or insert date via os.time() 
with format `"day(" .. os.time() .. ")"`.

Example
```lua
exports.mongodb:updateOne({
   collection="users",
   query = { _id = result[1]._id },
   update = { ["$set"] = {  last_login = "day(" .. os.time() .. ")" } } 
})
```

This will convert last_login from `"day(1554755493)"` to `ISODate('2019-04-08T20:31:33.000Z')`.

Hope this will improve this resource.

PS. I apologize if there are any errors.



